### PR TITLE
Remove unicode characters from code, add explicit encoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-© 2015-2018, ETH Zurich, Institut für Theoretische Physik
+(c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 Author: Dominik Gresch <greschd@gmx.ch>
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+© 2015-2018, ETH Zurich, Institut für Theoretische Physik
+Author: Dominik Gresch <greschd@gmx.ch>
+-->
+
 # TBmodels
 
 A tool for creating, modifying and evaluating tight-binding models

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,4 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 find -name "*.pyc" -delete;

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 find -name "*.pyc" -delete;
 find -name "*.pyo" -delete;
 find -name "__pycache__" -delete;

--- a/doc/replace_colors.py
+++ b/doc/replace_colors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/doc/replace_colors.py
+++ b/doc/replace_colors.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Author:  Dominik Gresch <greschd@gmx.ch>
-# Date:    09.10.2015 11:29:39 CEST
-# File:    replace_colors.py
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 
 import os
 import sys

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 # TBmodels documentation build configuration file, created by
 # sphinx-quickstart on Fri Oct 10 02:14:52 2014.
 #

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 # TBmodels documentation build configuration file, created by

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,3 +1,6 @@
+.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. Author: Dominik Gresch <greschd@gmx.ch>
+
 .. image:: images/tbmodels_logo.jpg
     :width: 250px
     :alt: TBmodels logo

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 .. Author: Dominik Gresch <greschd@gmx.ch>
 
 .. image:: images/tbmodels_logo.jpg

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -1,3 +1,6 @@
+.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. Author: Dominik Gresch <greschd@gmx.ch>
+
 .. _reference:
 
 Reference

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -1,4 +1,4 @@
-.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 .. Author: Dominik Gresch <greschd@gmx.ch>
 
 .. _reference:

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -25,6 +25,13 @@ Helper functions
     :members:
     :imported-members:
 
+Saving and loading (HDF5)
+-------------------------
+
+.. automodule:: tbmodels.io
+    :members:
+    :imported-members:
+
 .. _cli_reference:
 
 Command line interface

--- a/doc/source/simple_model.py
+++ b/doc/source/simple_model.py
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import tbmodels
 import itertools
 

--- a/doc/source/simple_model.py
+++ b/doc/source/simple_model.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import tbmodels

--- a/doc/source/symmetrize.rst
+++ b/doc/source/symmetrize.rst
@@ -1,4 +1,4 @@
-.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 .. Author: Dominik Gresch <greschd@gmx.ch>
 
 .. _symmetrize:

--- a/doc/source/symmetrize.rst
+++ b/doc/source/symmetrize.rst
@@ -1,3 +1,6 @@
+.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. Author: Dominik Gresch <greschd@gmx.ch>
+
 .. _symmetrize:
 
 Symmetrization

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1,3 +1,6 @@
+.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. Author: Dominik Gresch <greschd@gmx.ch>
+
 .. _tutorial:
 
 Tutorial

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1,4 +1,4 @@
-.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 .. Author: Dominik Gresch <greschd@gmx.ch>
 
 .. _tutorial:

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -1,4 +1,4 @@
-.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 .. Author: Dominik Gresch <greschd@gmx.ch>
 
 .. _whatsnew:

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -1,3 +1,6 @@
+.. © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+.. Author: Dominik Gresch <greschd@gmx.ch>
+
 .. _whatsnew:
 
 What's new

--- a/examples/cmdline/eigenvals/run.sh
+++ b/examples/cmdline/eigenvals/run.sh
@@ -1,1 +1,5 @@
+#!/bin/bash
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 tbmodels eigenvals -i input/silicon_model.hdf5 -k input/kpoints.hdf5 -o silicon_bands.hdf5

--- a/examples/cmdline/eigenvals/run.sh
+++ b/examples/cmdline/eigenvals/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 tbmodels eigenvals -i input/silicon_model.hdf5 -k input/kpoints.hdf5 -o silicon_bands.hdf5

--- a/examples/cmdline/parser/run.sh
+++ b/examples/cmdline/parser/run.sh
@@ -1,1 +1,5 @@
+#!/bin/bash
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 tbmodels parse -f input -p silicon -o silicon_model.hdf5

--- a/examples/cmdline/parser/run.sh
+++ b/examples/cmdline/parser/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 tbmodels parse -f input -p silicon -o silicon_model.hdf5

--- a/examples/cmdline/symmetrization/compare_bands.py
+++ b/examples/cmdline/symmetrization/compare_bands.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import tbmodels

--- a/examples/cmdline/symmetrization/compare_bands.py
+++ b/examples/cmdline/symmetrization/compare_bands.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Author:  Georg Winkler, Dominik Gresch <greschd@gmx.ch>
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import tbmodels
 import numpy as np

--- a/examples/cmdline/symmetrization/generate_symmetries.py
+++ b/examples/cmdline/symmetrization/generate_symmetries.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import numpy as np

--- a/examples/cmdline/symmetrization/generate_symmetries.py
+++ b/examples/cmdline/symmetrization/generate_symmetries.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Author:  Georg Winkler, Dominik Gresch <greschd@gmx.ch>
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import numpy as np
 import scipy.linalg as la

--- a/examples/kdotp/run.py
+++ b/examples/kdotp/run.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import tbmodels
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/kdotp/run.py
+++ b/examples/kdotp/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import tbmodels

--- a/examples/silicon/run.py
+++ b/examples/silicon/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/examples/silicon/run.py
+++ b/examples/silicon/run.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import os
 import shutil
 import subprocess

--- a/examples/symmetrization/nonsymmorphic_Si/symmetrize.py
+++ b/examples/symmetrization/nonsymmorphic_Si/symmetrize.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Author:  Georg Winkler, Dominik Gresch <greschd@gmx.ch>
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import os
 

--- a/examples/symmetrization/nonsymmorphic_Si/symmetrize.py
+++ b/examples/symmetrization/nonsymmorphic_Si/symmetrize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/examples/symmetrization/symmorphic_InAs/symmetrize.py
+++ b/examples/symmetrization/symmorphic_InAs/symmetrize.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Author:  Georg Winkler, Dominik Gresch <greschd@gmx.ch>
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import os
 

--- a/examples/symmetrization/symmorphic_InAs/symmetrize.py
+++ b/examples/symmetrization/symmorphic_InAs/symmetrize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Authors: Georg Winkler, Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
         [console_scripts]
         tbmodels=tbmodels._cli:cli
     ''',
-    license='GPL',
+    license='Apache 2.0',
     packages=['tbmodels', 'tbmodels._ptools']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import re
 try:
     from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import re

--- a/speed_test/test.py
+++ b/speed_test/test.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Author:  Dominik Gresch <greschd@gmx.ch>
-# Date:    07.07.2016 00:46:23 CEST
-# File:    test.py
+
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 
 import itertools
 

--- a/speed_test/test.py
+++ b/speed_test/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import itertools

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -4,7 +4,7 @@ r"""
 TBmodels is a tool for creating / loading and manipulating tight-binding models.
 """
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 # import order is important due to circular imports
 from . import helpers

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 r"""
 TBmodels is a tool for creating / loading and manipulating tight-binding models.

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -6,7 +6,7 @@ r"""
 TBmodels is a tool for creating / loading and manipulating tight-binding models.
 """
 
-__version__ = '1.3.2a1'
+__version__ = '1.3.2'
 
 # import order is important due to circular imports
 from . import helpers

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 r"""
 TBmodels is a tool for creating / loading and manipulating tight-binding models.
 """

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -6,7 +6,7 @@ r"""
 TBmodels is a tool for creating / loading and manipulating tight-binding models.
 """
 
-__version__ = '1.3.1'
+__version__ = '1.3.2a1'
 
 # import order is important due to circular imports
 from . import helpers

--- a/tbmodels/_check_compatibility.py
+++ b/tbmodels/_check_compatibility.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 """
 Utilities to check whether models are compatible, e.g. for adding.
 """

--- a/tbmodels/_check_compatibility.py
+++ b/tbmodels/_check_compatibility.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 Utilities to check whether models are compatible, e.g. for adding.

--- a/tbmodels/_cli.py
+++ b/tbmodels/_cli.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 """
 Defines the tbmodels command-line interface.
 """

--- a/tbmodels/_cli.py
+++ b/tbmodels/_cli.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 Defines the tbmodels command-line interface.

--- a/tbmodels/_kdotp.py
+++ b/tbmodels/_kdotp.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 Module defining k.p models. Note that this module should be considered temporary,

--- a/tbmodels/_kdotp.py
+++ b/tbmodels/_kdotp.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 """
 Module defining k.p models. Note that this module should be considered temporary,
 and should not be relied on having a fixed import position. Since it does not

--- a/tbmodels/_legacy_decode.py
+++ b/tbmodels/_legacy_decode.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 Defines decoding for the legacy (pre fsc.hdf5-io) HDF5 format.

--- a/tbmodels/_legacy_decode.py
+++ b/tbmodels/_legacy_decode.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 """
 Defines decoding for the legacy (pre fsc.hdf5-io) HDF5 format.
 """

--- a/tbmodels/_ptools/__init__.py
+++ b/tbmodels/_ptools/__init__.py
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import os
 __all__ = [
     f[:-3] for f in [os.path.basename(g) for g in os.listdir(os.path.dirname(os.path.abspath(__file__)))]

--- a/tbmodels/_ptools/__init__.py
+++ b/tbmodels/_ptools/__init__.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/tbmodels/_ptools/sparse_matrix.py
+++ b/tbmodels/_ptools/sparse_matrix.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Author:  Dominik Gresch <greschd@gmx.ch>
-# Date:    06.10.2015 17:35:33 CEST
-# File:    sparse_matrix.py
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 
 import numpy as np
 import scipy.sparse as sp

--- a/tbmodels/_ptools/sparse_matrix.py
+++ b/tbmodels/_ptools/sparse_matrix.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-import numpy as np
 import scipy.sparse as sp
 
 

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import re
 import os
 import copy
@@ -801,7 +804,7 @@ class Model(HDF5Enabled):
         Construct a k.p model around a given k-point. This is done by explicitly
         evaluating the derivatives which make up the Taylor expansion of the k.p
         models.
-        
+
         This method can currently only construct models using
         `convention 2  <http://www.physics.rutgers.edu/pythtb/_downloads/pythtb-formalism.pdf>`_
         for the Hamiltonian.

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import re

--- a/tbmodels/helpers.py
+++ b/tbmodels/helpers.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 This module contains a helper function to create a list of hoppings from a given matrix (:meth:`matrix_to_hop`).

--- a/tbmodels/helpers.py
+++ b/tbmodels/helpers.py
@@ -1,3 +1,5 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
 """
 This module contains a helper function to create a list of hoppings from a given matrix (:meth:`matrix_to_hop`).
 """

--- a/tbmodels/io.py
+++ b/tbmodels/io.py
@@ -1,5 +1,8 @@
 # © 2015-2018, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
+"""
+Defines functions for saving and loading in HDF5 format.
+"""
 
 import h5py
 import fsc.hdf5_io
@@ -9,13 +12,16 @@ from . import _legacy_decode
 
 __all__ = ['save']
 
-save = fsc.hdf5_io.save
+save = fsc.hdf5_io.save  # pylint: disable=invalid-name
 
 
 @export
 def load(file_path):
+    """
+    Load TBmodels objects from an HDF5 file.
+    """
     try:
         return fsc.hdf5_io.load(file_path)
     except ValueError:
-        with h5py.File(file_path, 'r') as hf:
-            return _legacy_decode._decode(hf)
+        with h5py.File(file_path, 'r') as hdf5_handle:
+            return _legacy_decode._decode(hdf5_handle)  # pylint: disable=protected-access

--- a/tbmodels/io.py
+++ b/tbmodels/io.py
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import h5py
 import fsc.hdf5_io
 from fsc.export import export

--- a/tbmodels/io.py
+++ b/tbmodels/io.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 """
 Defines functions for saving and loading in HDF5 format.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import os
 import json
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import os
-import json
 import pytest
-import numbers
 import operator
 import itertools
-import contextlib
 from functools import partial
 from collections import ChainMap
-from collections.abc import Iterable
 try:
     from functools import singledispatch
 except ImportError:

--- a/tests/parameters.py
+++ b/tests/parameters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 T_VALUES = [(t1, t2) for t1 in [-0.1, 0.2, 0.3] for t2 in [-0.2, 0.5]]

--- a/tests/parameters.py
+++ b/tests/parameters.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 T_VALUES = [(t1, t2) for t1 in [-0.1, 0.2, 0.3] for t2 in [-0.2, 0.5]]
 KPT = [(0.1, 0.2, 0.7), (-0.3, 0.5, 0.2), (0., 0., 0.), (0.1, -0.9, -0.7)]

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import numpy as np
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_arithmetic_invalid.py
+++ b/tests/test_arithmetic_invalid.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tbmodels
 import numpy as np

--- a/tests/test_arithmetic_invalid.py
+++ b/tests/test_arithmetic_invalid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_cli_eigenvals.py
+++ b/tests/test_cli_eigenvals.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import os

--- a/tests/test_cli_eigenvals.py
+++ b/tests/test_cli_eigenvals.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import os
 
 import pytest

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tempfile
 from click.testing import CliRunner

--- a/tests/test_cli_slice.py
+++ b/tests/test_cli_slice.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_cli_slice.py
+++ b/tests/test_cli_slice.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tempfile
 from click.testing import CliRunner

--- a/tests/test_cli_symmetrize.py
+++ b/tests/test_cli_symmetrize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_cli_symmetrize.py
+++ b/tests/test_cli_symmetrize.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tempfile
 from click.testing import CliRunner

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import itertools
 
 import pytest

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import itertools

--- a/tests/test_convention.py
+++ b/tests/test_convention.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import numpy as np

--- a/tests/test_convention.py
+++ b/tests/test_convention.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import numpy as np
 import pythtb as pt
 import tbmodels as tb

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import tempfile
 
 import pytest

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import tempfile

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 
 import tbmodels

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_hr_print.py
+++ b/tests/test_hr_print.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import tempfile
 
 import pytest

--- a/tests/test_hr_print.py
+++ b/tests/test_hr_print.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import tempfile
@@ -9,7 +9,6 @@ import tempfile
 import pytest
 
 import tbmodels
-import numpy as np
 
 from parameters import T_VALUES, KPT
 

--- a/tests/test_join_models.py
+++ b/tests/test_join_models.py
@@ -1,3 +1,6 @@
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import copy
 
 import pytest

--- a/tests/test_join_models.py
+++ b/tests/test_join_models.py
@@ -1,4 +1,6 @@
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# -*- coding: utf-8 -*-
+#
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import copy

--- a/tests/test_kdotp.py
+++ b/tests/test_kdotp.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import numpy as np
 

--- a/tests/test_kdotp.py
+++ b/tests/test_kdotp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_matrix_to_hoppings.py
+++ b/tests/test_matrix_to_hoppings.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 
 import tbmodels

--- a/tests/test_matrix_to_hoppings.py
+++ b/tests/test_matrix_to_hoppings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pickle

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pickle
 import tempfile
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest
-import tbmodels
 
 import numpy as np
-
-from tbmodels._ptools.sparse_matrix import csr
 
 from parameters import T_VALUES, KPT
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -5,8 +5,11 @@
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest
+import tbmodels  # pylint: disable=unused-import
 
 import numpy as np
+
+from tbmodels._ptools.sparse_matrix import csr  # pylint: disable=unused-import
 
 from parameters import T_VALUES, KPT
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tbmodels
 

--- a/tests/test_simple_model.py
+++ b/tests/test_simple_model.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 
 from parameters import T_VALUES, KPT

--- a/tests/test_simple_model.py
+++ b/tests/test_simple_model.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import numpy as np
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_sparse_dense.py
+++ b/tests/test_sparse_dense.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import tbmodels
 import numpy as np

--- a/tests/test_sparse_dense.py
+++ b/tests/test_sparse_dense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_to_kwant.py
+++ b/tests/test_to_kwant.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import itertools
 

--- a/tests/test_to_kwant.py
+++ b/tests/test_to_kwant.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_w90_pythtb.py
+++ b/tests/test_w90_pythtb.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 import numpy as np
 import pythtb as pt

--- a/tests/test_w90_pythtb.py
+++ b/tests/test_w90_pythtb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest

--- a/tests/test_wannier.py
+++ b/tests/test_wannier.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
 import pytest
 
 import tbmodels

--- a/tests/test_wannier.py
+++ b/tests/test_wannier.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# © 2015-2018, ETH Zurich, Institut für Theoretische Physik
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
 import pytest


### PR DESCRIPTION
This solves an issue where the code does not work if the locale set on the computer is not utf-8.