### PR TITLE
Add a 'distance_ratio_threshold' for 'nearest_atom' parsing

### DIFF
--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -14,8 +14,6 @@ What's new in TBmodels 1.4 (development version)
 New features
 ''''''''''''
 
-- Add ``--version`` option to the command-line interface, to print the current version.
-
 - The ``KdotpModel`` has been promoted from an internal-only interface to the public ``tbmodels.kdotp`` submodule.
 
 - The ``supercell`` method can be used to obtain a supercell tight-binding model.
@@ -26,9 +24,17 @@ New features
 
 - Add ``remove_small_hop`` and ``remove_long_range_hop`` methods to cut hoppings with small value or long distance, respectively. Both these methods operate in-place on the existing model.
 
+- When using ``pos_kind='nearest_atom'``, the ``from_wannier_files`` method (and by extension the ``from_wannier_folder`` method and ``parse`` command) have an additional check: The ratio between next-nearest and nearest distance can be no lower than a given ``distance_ratio_threshold``. Note that this is a backwards-incompatible change, because the check might fail for cases where parsing succeeded before. However, we expect a failing check to indicate an underlying problem in most cases. To disable the check, set ``distance_ratio_threshold=1``.
+
+Command-line interface
+``````````````````````
+
+- Add ``--version`` option to the command-line interface, to print the current version.
+
+- Add a ``--verbose`` option to the command-line interface, which causes informational output to be printed. By default, the CLI is now silent.
+
 - The command-line interfaces creating tight-binding models support a ``--sparsity`` flag to change the sparsity of the output model (valid options are ``as_input``, ``dense``, and ``sparse``). Setting ``--sparsity=sparse`` can significantly reduce the memory needed to store a model.
 
-- When using ``pos_kind='nearest_atom'``, the ``from_wannier_files`` method (and by extension the ``from_wannier_folder`` method and ``parse`` command) have an additional check: The ratio between next-nearest and nearest distance can be no lower than a given ``distance_ratio_threshold``. Note that this is a backwards-incompatible change, because the check might fail for cases where parsing succeeded before. However, we expect a failing check to indicate an underlying problem in most cases. To disable the check, set ``distance_ratio_threshold=1``.
 
 Experimental features
 '''''''''''''''''''''

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -28,6 +28,8 @@ New features
 
 - The command-line interfaces creating tight-binding models support a ``--sparsity`` flag to change the sparsity of the output model (valid options are ``as_input``, ``dense``, and ``sparse``). Setting ``--sparsity=sparse`` can significantly reduce the memory needed to store a model.
 
+- When using ``pos_kind='nearest_atom'``, the ``from_wannier_files`` method (and by extension the ``from_wannier_folder`` method and ``parse`` command) have an additional check: The ratio between next-nearest and nearest distance can be no lower than a given ``distance_ratio_threshold``. Note that this is a backwards-incompatible change, because the check might fail for cases where parsing succeeded before. However, we expect a failing check to indicate an underlying problem in most cases. To disable the check, set ``distance_ratio_threshold=1``.
+
 Experimental features
 '''''''''''''''''''''
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description="A tool for reading, creating and modifying tight-binding models.",
     python_requires=">=3.6",
     install_requires=[
-        'numpy', 'scipy>=0.14', 'h5py', 'fsc.export', 'symmetry-representation>=0.2', 'click', 'bands-inspect',
+        'numpy', 'scipy>=0.14', 'h5py', 'fsc.export', 'symmetry-representation>=0.2', 'click>=7.0, !=7.1.0', 'bands-inspect',
         'fsc.hdf5-io>=0.6.0'
     ],
     extras_require=EXTRAS_REQUIRE,

--- a/tbmodels/_cli.py
+++ b/tbmodels/_cli.py
@@ -91,15 +91,20 @@ def _write_output(model, output, sparsity):
     default='wannier',
     help="Which position to use for the orbitals."
 )
+@click.option('--distance-ratio-threshold', type=click.FloatRange(min=1.), default=3.)
 @_sparsity_option()
 @_output_option(default='model.hdf5', help='Path of the output file.')
-def parse(folder, prefix, output, pos_kind, sparsity):
+def parse(folder, prefix, output, pos_kind, distance_ratio_threshold, sparsity):
     """
     Parse Wannier90 output files and create an HDF5 file containing the tight-binding model.
     """
     click.echo("Parsing output files '{}*' ...".format(os.path.join(folder, prefix)))
     model = Model.from_wannier_folder(
-        folder=folder, prefix=prefix, ignore_orbital_order=True, pos_kind=pos_kind
+        folder=folder,
+        prefix=prefix,
+        ignore_orbital_order=True,
+        pos_kind=pos_kind,
+        distance_ratio_threshold=distance_ratio_threshold,
     )
     _write_output(model, output, sparsity=sparsity)
 

--- a/tbmodels/_exceptions.py
+++ b/tbmodels/_exceptions.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Defines custom exceptions to be used in TBmodels. The main purpose of
+these custom exceptions is their use in the CLI. Custom exceptions can
+be caught in the CLI functions.
+"""
+
+from enum import Enum
+
+import click
+
+__all__ = ('TbmodelsException', 'ExceptionMarker', 'ParseExceptionMarker')
+
+
+class ExceptionMarker(Enum):
+    """
+    A list of markers to be used in custom TBmodels exceptions.
+    """
+
+
+class TbmodelsException(click.ClickException):
+    """Base class for the custom TBmodels exceptions."""
+    def __init__(self, msg, exception_marker: ExceptionMarker):
+        formatted_msg = f'[{exception_marker.name}] {msg}'
+        super().__init__(formatted_msg)
+
+
+class ParseExceptionMarker(ExceptionMarker):
+    INCOMPLETE_WSVEC_FILE = 'The seedname_wsvec.dat file is empty or incomplete.'
+    AMBIGUOUS_NEAREST_ATOM_POSITIONS = 'The nearest atom to use for position parsing is ambiguous.'  # pylint: disable=invalid-name

--- a/tbmodels/_exceptions.py
+++ b/tbmodels/_exceptions.py
@@ -19,10 +19,19 @@ class ExceptionMarker(Enum):
 
 
 class TbmodelsException(click.ClickException):
+    """
+    Custom exception class for TBmodels errors. Errors which use this
+    exception class will be caught and formatted properly in the CLI.
+    """
+    #: The exit code for this exception
+    exit_code = 3
     """Base class for the custom TBmodels exceptions."""
-    def __init__(self, msg, exception_marker: ExceptionMarker):
-        formatted_msg = f'[{exception_marker.name}] {msg}'
-        super().__init__(formatted_msg)
+    def __init__(self, message, exception_marker: ExceptionMarker):
+        super().__init__(message)
+        self.exception_marker = exception_marker
+
+    def format_message(self):
+        return f'[{self.exception_marker.name}] {super().format_message()}'
 
 
 class ParseExceptionMarker(ExceptionMarker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,13 @@ def cli_sparsity_arguments(cli_sparsity):
     return ['--sparsity', cli_sparsity]
 
 
+@pytest.fixture(params=[False, True])
+def cli_verbosity_argument(request):
+    if request.param:
+        return ['--verbose']
+    return []
+
+
 @pytest.fixture
 def modify_reference_model_sparsity(cli_sparsity):
     """

--- a/tests/test_cli_eigenvals.py
+++ b/tests/test_cli_eigenvals.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from tbmodels._cli import cli
 
 
-def test_cli_eigenvals(sample):
+def test_cli_eigenvals(sample, cli_verbosity_argument):
     """
     Test the 'eigenvals' command.
     """
@@ -25,11 +25,12 @@ def test_cli_eigenvals(sample):
     runner = CliRunner()
     with tempfile.NamedTemporaryFile() as out_file:
         run = runner.invoke(
-            cli, [
+            cli,
+            [
                 'eigenvals', '-o', out_file.name, '-k',
                 os.path.join(samples_dir, 'kpoints.hdf5'), '-i',
                 os.path.join(samples_dir, 'silicon_model.hdf5')
-            ],
+            ] + cli_verbosity_argument,
             catch_exceptions=False
         )
         print(run.output)

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -52,7 +52,7 @@ def test_ambiguous_nearest_atom(prefix, sample):
     in the expected error for cases where the nearest atom position is
     ambiguous.
     """
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     with tempfile.NamedTemporaryFile() as out_file:
         run = runner.invoke(
             cli, [
@@ -61,5 +61,6 @@ def test_ambiguous_nearest_atom(prefix, sample):
             ],
             catch_exceptions=False
         )
-        print('OUTPUT:', run.output)
-        assert 'Error: [AMBIGUOUS_NEAREST_ATOM_POSITIONS]' in run.output
+        print('STDOUT:', run.stdout)
+        print('STDERR:', run.stderr)
+        assert run.stderr.startswith('Error: [AMBIGUOUS_NEAREST_ATOM_POSITIONS]')

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -15,23 +15,31 @@ from tbmodels._cli import cli
 
 
 @pytest.mark.parametrize('pos_kind', ['wannier', 'nearest_atom'])
-@pytest.mark.parametrize('prefix', ['silicon', 'bi'])
-def test_cli_parse(
-    models_equal, prefix, sample, pos_kind, cli_sparsity_arguments, modify_reference_model_sparsity
+@pytest.mark.parametrize('prefix, distance_ratio_threshold', [('silicon', 2.), ('bi', 1)])
+def test_cli_parse(  # pylint: disable=too-many-arguments
+    models_equal, prefix, sample, pos_kind, cli_sparsity_arguments, modify_reference_model_sparsity,
+    distance_ratio_threshold
 ):
     """Test the 'parse' command with different 'prefix' and 'pos_kind'."""
     runner = CliRunner()
     with tempfile.NamedTemporaryFile() as out_file:
+        if distance_ratio_threshold is None:
+            distance_ratio_arguments = []
+            distance_ratio_kwargs = {}
+        else:
+            distance_ratio_arguments = ['--distance-ratio-threshold', str(distance_ratio_threshold)]
+            distance_ratio_kwargs = {'distance_ratio_threshold': distance_ratio_threshold}
         run = runner.invoke(
             cli,
             ['parse', '-o', out_file.name, '-f',
-             sample(''), '-p', prefix, '--pos-kind', pos_kind] + cli_sparsity_arguments,
+             sample(''), '-p', prefix, '--pos-kind', pos_kind] + cli_sparsity_arguments +
+            distance_ratio_arguments,
             catch_exceptions=False
         )
         print(run.output)
         model_res = tbmodels.Model.from_hdf5_file(out_file.name)
     model_reference = tbmodels.Model.from_wannier_folder(
-        folder=sample(''), prefix=prefix, pos_kind=pos_kind
+        folder=sample(''), prefix=prefix, pos_kind=pos_kind, **distance_ratio_kwargs
     )
     modify_reference_model_sparsity(model_reference)
     models_equal(model_res, model_reference)

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -17,7 +17,7 @@ from tbmodels._cli import cli
 @pytest.mark.parametrize('pos_kind', ['wannier', 'nearest_atom'])
 @pytest.mark.parametrize('prefix, distance_ratio_threshold', [('silicon', 2.), ('bi', 1)])
 def test_cli_parse(  # pylint: disable=too-many-arguments
-    models_equal, prefix, sample, pos_kind, cli_sparsity_arguments, modify_reference_model_sparsity,
+    models_equal, prefix, sample, pos_kind, cli_sparsity_arguments, cli_verbosity_argument, modify_reference_model_sparsity,
     distance_ratio_threshold
 ):
     """Test the 'parse' command with different 'prefix' and 'pos_kind'."""
@@ -33,7 +33,7 @@ def test_cli_parse(  # pylint: disable=too-many-arguments
             cli,
             ['parse', '-o', out_file.name, '-f',
              sample(''), '-p', prefix, '--pos-kind', pos_kind] + cli_sparsity_arguments +
-            distance_ratio_arguments,
+            cli_verbosity_argument + distance_ratio_arguments,
             catch_exceptions=False
         )
         print(run.output)

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -52,7 +52,7 @@ def test_ambiguous_nearest_atom(prefix, sample):
     in the expected error for cases where the nearest atom position is
     ambiguous.
     """
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     with tempfile.NamedTemporaryFile() as out_file:
         run = runner.invoke(
             cli, [
@@ -61,4 +61,5 @@ def test_ambiguous_nearest_atom(prefix, sample):
             ],
             catch_exceptions=False
         )
-        assert run.stderr.startswith('Error: [AMBIGUOUS_NEAREST_ATOM_POSITIONS]')
+        print('OUTPUT:', run.output)
+        assert 'Error: [AMBIGUOUS_NEAREST_ATOM_POSITIONS]' in run.output

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -43,3 +43,22 @@ def test_cli_parse(  # pylint: disable=too-many-arguments
     )
     modify_reference_model_sparsity(model_reference)
     models_equal(model_res, model_reference)
+
+
+@pytest.mark.parametrize('prefix', ['silicon', 'bi'])
+def test_ambiguous_nearest_atom(prefix, sample):
+    """
+    Test that the 'parse' command with `pos_kind='nearest_atom' results
+    in the expected error for cases where the nearest atom position is
+    ambiguous.
+    """
+    runner = CliRunner(mix_stderr=False)
+    with tempfile.NamedTemporaryFile() as out_file:
+        run = runner.invoke(
+            cli, [
+                'parse', '-o', out_file.name, '-f',
+                sample(''), '-p', prefix, '--pos-kind', 'nearest_atom'
+            ],
+            catch_exceptions=False
+        )
+        assert run.stderr.startswith('Error: [AMBIGUOUS_NEAREST_ATOM_POSITIONS]')

--- a/tests/test_cli_slice.py
+++ b/tests/test_cli_slice.py
@@ -16,7 +16,8 @@ from tbmodels._cli import cli
 
 @pytest.mark.parametrize('slice_idx', [(3, 1, 2), (0, 1, 4, 2, 3, 5, 6, 8, 7, 9, 10, 11, 12)])
 def test_cli_slice(
-    models_equal, slice_idx, sample, cli_sparsity_arguments, modify_reference_model_sparsity
+    models_equal, slice_idx, sample, cli_sparsity_arguments, cli_verbosity_argument,
+    modify_reference_model_sparsity
 ):
     """
     Check that using the CLI to slice a tight-binding model produces
@@ -32,7 +33,7 @@ def test_cli_slice(
                 out_file.name,
                 '-i',
                 input_file,
-            ] + cli_sparsity_arguments + [str(x) for x in slice_idx],
+            ] + cli_sparsity_arguments + cli_verbosity_argument + [str(x) for x in slice_idx],
             catch_exceptions=False
         )
         print(run.output)

--- a/tests/test_cli_symmetrize.py
+++ b/tests/test_cli_symmetrize.py
@@ -16,7 +16,8 @@ from tbmodels._cli import cli
 
 
 def test_cli_symmetrize(
-    models_close, sample, cli_sparsity_arguments, modify_reference_model_sparsity
+    models_close, sample, cli_sparsity_arguments, cli_verbosity_argument,
+    modify_reference_model_sparsity
 ):
     """
     Test the 'symmetrize' command.
@@ -29,7 +30,7 @@ def test_cli_symmetrize(
                 'symmetrize', '-o', out_file.name, '-s',
                 sample('InAs_symmetries.hdf5'), '-i',
                 sample('InAs_nosym.hdf5')
-            ] + cli_sparsity_arguments,
+            ] + cli_sparsity_arguments + cli_verbosity_argument,
             catch_exceptions=False
         )
         print(run.output)

--- a/tests/test_wannier.py
+++ b/tests/test_wannier.py
@@ -59,7 +59,9 @@ def test_wannier_hr_wsvec_xyz(hr_name, wsvec_name, xyz_name, sample):
     xyz_file = sample(xyz_name)
     # cannot determine reduced pos if uc is not given
     with pytest.raises(ValueError):
-        tbmodels.Model.from_wannier_files(hr_file=hr_file, wsvec_file=wsvec_file, xyz_file=xyz_file)
+        tbmodels.Model.from_wannier_files(
+            hr_file=hr_file, wsvec_file=wsvec_file, xyz_file=xyz_file, distance_ratio_threshold=1.
+        )
 
 
 @pytest.mark.parametrize(
@@ -161,9 +163,10 @@ def test_wannier_all(
         xyz_file=xyz_file,
         win_file=win_file,
         pos_kind=pos_kind,
+        distance_ratio_threshold=1.
     )
     model2 = tbmodels.Model.from_wannier_files(
-        hr_file=hr_file, wsvec_file=wsvec_file, win_file=win_file
+        hr_file=hr_file, wsvec_file=wsvec_file, win_file=win_file, distance_ratio_threshold=1.
     )
     hamiltonian_list = np.array([model.hamilton(k) for k in KPT])
 


### PR DESCRIPTION
Fixes #66 

When parsing with ``pos_kind="nearest_atom"``, add a check that computes the ratio of next-nearest / nearest atom. If it is below the given threshold, an error is thrown. The purpose of this check is to detect cases where it is inappropriate to use ``nearest_atom`` parsing, because the Wannier centers have shifted so much that they are no longer close to the original atoms, and might be misidentified.