### PR TITLE
Remove work-around for setuptools 'attr:'.

### DIFF
--- a/.travis-data/install_script.sh
+++ b/.travis-data/install_script.sh
@@ -8,6 +8,7 @@ set -ev
 cd ${TRAVIS_BUILD_DIR}
 
 pip install codecov
+pip install -U setuptools wheel
 
 case "$INSTALL_TYPE" in
     dev)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel", "fastentrypoints"]
+requires = ["setuptools >= 46.4.0", "wheel", "fastentrypoints"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = tbmodels
 author = Dominik Gresch
 author_email = greschd@gmx.ch
-version = attr: tbmodels._version.__version__
+version = attr: tbmodels.__version__
 url = https://tbmodels.greschd.ch
 description = A tool for reading, creating and modifying tight-binding models.
 long_description = file: README.md

--- a/tbmodels/__init__.py
+++ b/tbmodels/__init__.py
@@ -4,7 +4,7 @@
 # Author: Dominik Gresch <greschd@gmx.ch>
 """A tool for creating / loading and manipulating tight-binding models."""
 
-from ._version import __version__
+__version__ = "1.4.1"
 
 # import order is important due to circular imports
 from . import helpers

--- a/tbmodels/_version.py
+++ b/tbmodels/_version.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-"""
-Helper module that defines the TBmodels version. The purpose of this
-module is to make the '__version__' available without any external
-dependencies, for the purposes of the build system.
-"""
-
-__version__ = "1.4.1"


### PR DESCRIPTION
The setuptools 'attr' can now load attributes defined at the
module top-level without loading the module itself (since 46.4).
As such, we no longer need the separate '_version.py' file, and
instead require an up-to-date setuptools.