### PR TITLE
Use the rounded `new_R` values in `change_unit_cell`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         install-type: [dev]
         include:
         - python-version: 3.8

--- a/.github/workflows_source/ci.yml
+++ b/.github/workflows_source/ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         install-type: [dev]
         include:
           - python-version: 3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v2.11.0
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,9 +31,6 @@ strict_equality = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
 
-[mypy-numpy.*]
-ignore_missing_imports = True
-
 [mypy-scipy.*]
 ignore_missing_imports = True
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,4 @@
 filterwarnings =
     error
     ignore::ImportWarning
-    ignore:numpy.dtype size changed
-    ignore:numpy.ufunc size changed
-    ignore:the imp module is deprecated
 junit_family = xunit2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Natural Language :: English
     Operating System :: Unix
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -27,7 +26,7 @@ classifiers =
     Topic :: Scientific/Engineering :: Physics
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     fastentrypoints
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
 install_requires =
     numpy
     scipy>=0.15
-    h5py>=3.0.0
+    h5py>=3.2.0
     fsc.export
     symmetry-representation>=0.2
     click>=7.0, !=7.1.0

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -633,13 +633,15 @@ class Model(HDF5Enabled):
                 wannier_pos_cartesian = np.array(wannier_pos_list_cartesian)
                 atom_pos_cartesian = np.array([a.pos for a in atom_list_cartesian])
                 if pos_kind == "wannier":
-                    pos_cartesian = wannier_pos_cartesian
+                    pos_cartesian: ty.Union[
+                        ty.List[np.ndarray], np.ndarray
+                    ] = wannier_pos_cartesian
                 elif pos_kind == "nearest_atom":
                     if distance_ratio_threshold < 1:
                         raise ValueError(
                             "Invalid value for 'distance_ratio_threshold': must be >= 1."
                         )
-                    pos_cartesian = []
+                    pos_cartesian = ty.cast(ty.List[np.ndarray], [])
                     for p in wannier_pos_cartesian:
                         p_reduced = la.solve(kwargs["uc"].T, np.array(p).T).T
                         T_base = np.floor(p_reduced)
@@ -1130,7 +1132,7 @@ class Model(HDF5Enabled):
             H = pos_exponential.conjugate().transpose((0, 2, 1)) * H * pos_exponential
 
         if single_point:
-            return H[0]
+            return ty.cast(np.ndarray, H[0])
         return H
 
     def eigenval(
@@ -1149,7 +1151,7 @@ class Model(HDF5Enabled):
         hamiltonians = self.hamilton(k)
         if hamiltonians.ndim == 3:
             return [la.eigvalsh(ham) for ham in hamiltonians]
-        return la.eigvalsh(hamiltonians)
+        return ty.cast(np.ndarray, la.eigvalsh(hamiltonians))
 
     # -------------------MODIFYING THE MODEL ----------------------------#
     def add_hop(
@@ -1320,7 +1322,7 @@ class Model(HDF5Enabled):
         # change existing matrices
         with contextlib.suppress(AttributeError):
             for k, v in self.hop.items():
-                self.hop[k] = self._matrix_type(v)
+                self.hop[k] = self._matrix_type(v)  # type: ignore
 
     # If Python 3.4 support is dropped this could be made more straightforwardly
     # However, for now the default pickle protocol (and thus multiprocessing)
@@ -1592,7 +1594,7 @@ class Model(HDF5Enabled):
                 )
             # convert to reduced coordinates
             if uc is None:
-                new_uc = self.uc
+                new_uc: ty.Optional[np.ndarray] = self.uc
                 uc_reduced = np.eye(self.dim)
             else:
                 new_uc = np.array(uc)

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -1635,7 +1635,7 @@ class Model(HDF5Enabled):
         for R, hop_mat in self.hop.items():
             new_R = la.solve(uc_reduced.T, R)
             assert np.allclose(np.round(new_R), new_R)
-            new_R = tuple(new_R.astype(int))
+            new_R = tuple(np.round(new_R).astype(int))
             new_hop[new_R] = hop_mat
 
         return Model(

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -1274,8 +1274,8 @@ class Model(HDF5Enabled):
                 "determine the cartesian distance between orbitals."
             )
         pos_cart = (self.uc.T @ self.pos.T).T
-        pos_offset_cart = pos_cart.reshape(1, -1, self.dim) - pos_cart.reshape(
-            -1, 1, self.dim
+        pos_offset_cart = pos_cart.reshape((1, -1, self.dim)) - pos_cart.reshape(
+            (-1, 1, self.dim)
         )
 
         # Cast to list because the dictionary is modified in the loop.

--- a/tbmodels/helpers.py
+++ b/tbmodels/helpers.py
@@ -17,7 +17,7 @@ def matrix_to_hop(
     orbitals: ty.Optional[ty.Sequence[int]] = None,
     R: ty.Sequence[int] = (0, 0, 0),
     multiplier: float = 1.0,
-) -> ty.List[ty.List[ty.Union[complex, int, np.ndarray]]]:
+) -> ty.List[ty.Tuple[complex, int, int, np.ndarray]]:
     r"""
     Turns a square matrix into a series of hopping terms.
 
@@ -40,11 +40,11 @@ def matrix_to_hop(
     for i, row in enumerate(mat):
         for j, x in enumerate(row):
             hop.append(
-                [
+                (
                     multiplier * x,
                     orbitals[i],
                     orbitals[j],
                     np.array(R, dtype=int),
-                ]
+                )
             )
     return hop

--- a/tbmodels/kdotp.py
+++ b/tbmodels/kdotp.py
@@ -68,13 +68,16 @@ class KdotpModel(SimpleHDF5Mapping):
         else:
             single_point = False
 
-        ham: np.ndarray = sum(
-            np.prod(k_array ** k_powers, axis=-1).reshape(-1, 1, 1)
-            * mat[np.newaxis, :, :]
-            for k_powers, mat in self.taylor_coefficients.items()
+        ham = ty.cast(
+            np.ndarray,
+            sum(
+                np.prod(k_array ** k_powers, axis=-1).reshape(-1, 1, 1)
+                * mat[np.newaxis, :, :]
+                for k_powers, mat in self.taylor_coefficients.items()
+            ),
         )
         if single_point:
-            return ham[0]
+            return ty.cast(np.ndarray, ham[0])
         return ham
 
     def eigenval(
@@ -93,4 +96,4 @@ class KdotpModel(SimpleHDF5Mapping):
         hamiltonians = self.hamilton(k)
         if hamiltonians.ndim == 3:
             return [la.eigvalsh(ham) for ham in hamiltonians]
-        return la.eigvalsh(hamiltonians)
+        return ty.cast(np.ndarray, la.eigvalsh(hamiltonians))


### PR DESCRIPTION
Previously, the `new_R` values were checked to be close to an
integer, but then the conversion to `int` happened directly via
`astype(int)` instead of using the rounded values.

This could lead to incorrect results - but it is not expected to
have been common, because the new unit cell in reduced coordinates
is an integer matrix.