### PR TITLE
Bump fsc.hdf5-io requirement to 1.0.1, to be compatible with h5py.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     symmetry-representation>=0.2
     click>=7.0, !=7.1.0
     bands-inspect
-    fsc.hdf5-io>=0.6.0
+    fsc.hdf5-io>=1.0.1
 packages = find:
 
 [options.extras_require]


### PR DESCRIPTION
Since we require h5py 3.x, the fsc.hdf5-io requirement also needs
to be updated to a version that supports newer h5py.