### PR TITLE
Limit find_packages to 'tbmodels' and 'tbmodels.*'.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,3 +68,8 @@ fsc.hdf5_io.load =
 
 [options.package_data]
 tbmodels = py.typed
+
+[options.packages.find]
+include =
+    tbmodels
+    tbmodels.*


### PR DESCRIPTION
Previously, a directory containing an '__init__.py' outside of
'tbmodels/' would cause the corresponding Python package to be
installed when pip-installing TBmodels.