### PR TITLE
Fix pymatgen imports in symmetrization example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         install-type: [dev]
         include:
         - python-version: 3.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
         INSTALL_TYPE: ${{ matrix.install-type }}
       run: .ci/install_script.sh
     - name: Build documentation
-      env:
-        READTHEDOCS: 'True'
       run: make SPHINXOPTS='-nW' -C doc html
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build documentation
       env:
         READTHEDOCS: 'True'
-      run: SPHINXOPTS='-nW' make -C doc html
+      run: make SPHINXOPTS='-nW' -C doc html
     - uses: actions/upload-artifact@v2
       with:
         name: doc-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows_source/ci.yml
+++ b/.github/workflows_source/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [pull_request]
 
 _anchors:
   checkout: &CHECKOUT

--- a/.github/workflows_source/ci.yml
+++ b/.github/workflows_source/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build documentation
         env:
           READTHEDOCS: "True"
-        run: SPHINXOPTS='-nW' make -C doc html
+        run: make SPHINXOPTS='-nW' -C doc html
       - uses: actions/upload-artifact@v2
         with:
           name: doc-build

--- a/.github/workflows_source/ci.yml
+++ b/.github/workflows_source/ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         install-type: [dev]
         include:
           - python-version: 3.8

--- a/.github/workflows_source/ci.yml
+++ b/.github/workflows_source/ci.yml
@@ -46,8 +46,6 @@ jobs:
       - *PYTHON_SETUP
       - *INSTALL_PROJECT
       - name: Build documentation
-        env:
-          READTHEDOCS: "True"
         run: make SPHINXOPTS='-nW' -C doc html
       - uses: actions/upload-artifact@v2
         with:

--- a/clean
+++ b/clean
@@ -1,0 +1,6 @@
+# (c) 2015-2018, ETH Zurich, Institut fuer Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+
+find -name "*.pyc" -delete;
+find -name "*.pyo" -delete;
+find -name "__pycache__" -delete;

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/devdocs/", None),
-    "symmetry-representation": ("http://z2pack.ethz.ch/symmetry-representation/", None),
+    "symmetry-representation": ("http://symmetry-representation.greschd.ch//", None),
     "fsc.hdf5-io": ("http://frescolinogroup.github.io/frescolino/pyhdf5io/0.5/", None),
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,10 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/devdocs/", None),
-    "symmetry-representation": ("http://symmetry-representation.greschd.ch//", None),
+    "symmetry-representation": (
+        "http://symmetry-representation.greschd.ch/en/latest",
+        None,
+    ),
     "fsc.hdf5-io": ("http://frescolinogroup.github.io/frescolino/pyhdf5io/0.5/", None),
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,11 +41,13 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/devdocs/", None),
     "symmetry-representation": ("http://z2pack.ethz.ch/symmetry-representation/", None),
     "fsc.hdf5-io": ("http://frescolinogroup.github.io/frescolino/pyhdf5io/0.5/", None),
 }
 
 nitpick_ignore = [("py:class", "array")]
+nitpick_ignore_regex = [("py:class", "numpy.*"), ("py:class", "ty.*")]
 ipython_warning_is_error = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/symmetrize.rst
+++ b/doc/source/symmetrize.rst
@@ -115,13 +115,14 @@ Next, we use ``pymatgen`` to determine the space group symmetries of our crystal
 
 .. ipython::
 
-    In [0]: import pymatgen as mg
+    In [0]: from pymatgen.core import Structure
+       ...: from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
-    In [0]: structure = mg.Structure(
+    In [0]: structure = Structure(
        ...:     lattice=model_nosym.uc, species=['Si', 'Si'], coords=np.array(coords)
        ...: )
 
-    In [0]: analyzer = mg.symmetry.analyzer.SpacegroupAnalyzer(structure)
+    In [0]: analyzer = SpacegroupAnalyzer(structure)
 
     In [0]: sym_ops = analyzer.get_symmetry_operations(cartesian=False)
 

--- a/doc/source/symmetrize.rst
+++ b/doc/source/symmetrize.rst
@@ -32,7 +32,7 @@ The model is located in the ``examples`` directory of the TBmodels source. You w
 .. ipython::
 
     In [0]: model_nosym =  tbmodels.io.load(
-       ...:     EXAMPLES_DIR / 'symmetrization' / 'nonsymmorphic_Si'/'data' / 'model_nosym.hdf5'
+       ...:     EXAMPLES_DIR / 'symmetrization' / 'nonsymmorphic_Si' / 'data' / 'model_nosym.hdf5'
        ...: )
 
 
@@ -114,6 +114,7 @@ Note that we use the ``numeric=True`` flag here. This keyword is used to switch 
 Next, we use ``pymatgen`` to determine the space group symmetries of our crystal:
 
 .. ipython::
+    :okwarning:
 
     In [0]: from pymatgen.core import Structure
        ...: from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find:
 kwant =
     kwant
 dev =
-    kwant
+    # kwant
     pytest~=6.0
     pytest-cov
     pythtb

--- a/tbmodels/_tb_model.py
+++ b/tbmodels/_tb_model.py
@@ -860,7 +860,7 @@ class Model(HDF5Enabled):
 
         .. note :: The TBmodels - Kwant interface is experimental. Use it with caution.
         """
-        import kwant  # pylint: disable=import-outside-toplevel
+        import kwant  # pylint: disable=import-outside-toplevel,import-error
 
         sublattices = self._get_sublattices()
         uc = self.uc if self.uc is not None else np.eye(self.dim)
@@ -874,7 +874,7 @@ class Model(HDF5Enabled):
 
         .. note :: The TBmodels - Kwant interface is experimental. Use it with caution.
         """
-        import kwant  # pylint: disable=import-outside-toplevel
+        import kwant  # pylint: disable=import-outside-toplevel,import-error
 
         sublattices = self._get_sublattices()
         if kwant_sublattices is None:

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -1,5 +1,0 @@
-pytest
-pytest-cov
-pythtb
-kwant
-git+https://gitlab.kwant-project.org/cwg/wraparound.git

--- a/tests/test_to_kwant.py
+++ b/tests/test_to_kwant.py
@@ -13,10 +13,18 @@ import pytest
 import numpy as np
 import scipy.linalg as la
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import kwant
-from kwant import wraparound
+pytest.mark.xfail(
+    reason="Kwant tests are disabled since kwant pip installation is broken."
+)
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import kwant
+    from kwant import wraparound
+except ImportError:
+    # allow test collection
+    pass
 
 from parameters import T_VALUES, KPT
 

--- a/tests/test_to_kwant.py
+++ b/tests/test_to_kwant.py
@@ -13,7 +13,7 @@ import pytest
 import numpy as np
 import scipy.linalg as la
 
-pytest.mark.xfail(
+pytestmark = pytest.mark.xfail(
     reason="Kwant tests are disabled since kwant pip installation is broken."
 )
 


### PR DESCRIPTION
Fix incorrect imports from pymatgen in symmetrization example, caused by a newer pymatgen version.

Remove `kwant` dev dependency and mark tests xfail, due to failing pip install of `kwant`.