### PR TITLE
Pin click, astroid for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        additional_dependencies:
+        - click<8.1
 
   - repo: local
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     h5py>=3.2.0
     fsc.export
     symmetry-representation>=0.2
-    click>=7.0, !=7.1.0
+    click>=7.0, !=7.1.0, <8.1
     bands-inspect
     fsc.hdf5-io>=1.0.1
 packages = find:
@@ -53,7 +53,8 @@ dev =
     ipython>=7.10
     sphinx-click
     black==20.8b1
-    pre-commit
+    pre-commit<2
+    astroid==2.4.0
     pylint==2.6.0
     isort==5.5.1
     mypy==0.812


### PR DESCRIPTION
Pin versions of pre-commit dependencies in order to get pre-commit 
working again.
Will address updating the pre-commit dependencies (and maybe switching
to `poetry`) in a separate PR.
